### PR TITLE
Add 'GitHub Skills' activity (issue #6)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -77,6 +77,14 @@ activities = {
     }
 }
 
+# Added activity: GitHub Skills (requested in issue #6)
+activities["GitHub Skills"] = {
+    "description": "Practical coding and collaboration workshops powered by GitHub\nLearn git, GitHub workflows, and collaboration skills useful for certifications.",
+    "schedule": "TBD — check announcements (registrations close soon)",
+    "max_participants": 25,
+    "participants": []
+}
+
 
 @app.get("/")
 def root():


### PR DESCRIPTION
This PR adds the missing "GitHub Skills" activity to the app's in-memory activities list. The activity was requested in issue #6 and is time-sensitive (registrations close soon). This change adds the activity entry with a description, placeholder schedule, and capacity. It's a minimal, non-breaking change intended to let students sign up immediately.

Files changed:
- src/app.py: added the "GitHub Skills" activity entry

Next steps (recommendation):
- If you keep activities in a file per issue #3, migrate this entry into that JSON file.
- Consider updating the frontend to show the new activity prominently and add registration details.

Signed-off-by: automated triage